### PR TITLE
Move install.sh into the Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,11 +14,20 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 # Copy installation scripts, and perform the dependency installation.
-COPY docker/install.sh .
 COPY docker/requirements.txt .
 COPY docker/requirements_ros.txt .
-RUN ./install.sh
-RUN rm install.sh requirements.txt requirements_ros.txt
+
+RUN apt-get update && apt-get dist-upgrade --yes
+
+RUN apt-get update && apt-get install --no-install-recommends --yes $(cat requirements.txt)
+
+RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+
+RUN curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
+
+RUN apt-get update && apt-get install --no-install-recommends -y $(cat requirements_ros.txt)
+
+RUN rm requirements.txt requirements_ros.txt
 
 # Create a user with passwordless sudo
 RUN adduser --uid $USERID --gecos "ekumen developer" --disabled-password $USER

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-apt-get update && apt-get install --no-install-recommends -y $(cat requirements.txt)
-
-sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
-
-apt-get update && apt-get install --no-install-recommends -y $(cat requirements_ros.txt)


### PR DESCRIPTION
I moved the install.sh instructions inside the Dockerfile in order to leverage the docker layering system, this is specifically painful when trying to build on a spotty/slow network (i.e: Ekuthon). With this approach, once a step is passed, it is cached (as opposed to having to have all of the install.sh steps to succeed for a layer to be created & cached)

Feel free to dismiss.